### PR TITLE
Add basic AI 3D personality module

### DIFF
--- a/3Dword.py
+++ b/3Dword.py
@@ -1,0 +1,67 @@
+class AI3DPersonality:
+    """Simple AI 3D personality module with basic emotional interaction.
+
+    The module provides a minimal interface for setting an emotion and retrieving
+    a textual expression describing the 3D avatar's face. It supports both
+    English and Chinese responses.
+    """
+
+    _expressions = {
+        "neutral": {"en": "neutral expression", "zh": "中性表情"},
+        "happy": {"en": "smiling brightly", "zh": "燦爛微笑"},
+        "sad": {"en": "looking sad", "zh": "悲傷表情"},
+        "angry": {"en": "showing anger", "zh": "憤怒表情"},
+    }
+
+    def __init__(self, name: str):
+        self.name = name
+        self.emotion = "neutral"
+
+    def set_emotion(self, emotion: str) -> None:
+        """Update the avatar's current emotion.
+
+        Parameters
+        ----------
+        emotion: str
+            One of ``neutral``, ``happy``, ``sad`` or ``angry``.
+        """
+        if emotion not in self._expressions:
+            raise ValueError(f"Unsupported emotion: {emotion}")
+        self.emotion = emotion
+
+    def get_expression(self, language: str = "en") -> str:
+        """Return a textual description of the avatar's facial expression.
+
+        Parameters
+        ----------
+        language: str
+            ``en`` for English or ``zh`` for Chinese.
+        """
+        if language not in ("en", "zh"):
+            raise ValueError("language must be 'en' or 'zh'")
+        return self._expressions[self.emotion][language]
+
+    def interact(self, message: str, language: str = "en") -> str:
+        """Generate a simple response reflecting the current emotion.
+
+        Parameters
+        ----------
+        message: str
+            User's input message.
+        language: str
+            ``en`` or ``zh`` to select the response language.
+        """
+        templates = {
+            "en": "{name} ({emotion}) says: I hear you saying '{message}'.",
+            "zh": "{name}（{emotion}）說：我聽到了你說『{message}』。",
+        }
+        if language not in templates:
+            raise ValueError("language must be 'en' or 'zh'")
+        return templates[language].format(
+            name=self.name,
+            emotion=self._expressions[self.emotion][language],
+            message=message,
+        )
+
+
+__all__ = ["AI3DPersonality"]


### PR DESCRIPTION
## Summary
- add `AI3DPersonality` class in new `3Dword.py` providing simple emotional expressions and bilingual interaction

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68983bfadb94832da1288d5603264008