### PR TITLE
feat: add ping-sync script for alignment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@ share/python-wheels/
 *.egg
 MANIFEST
 
+# Node dependencies
+node_modules/
+
 # PyInstaller
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.

--- a/README.md
+++ b/README.md
@@ -55,6 +55,14 @@ curl http://localhost:5000/info
 python test_comprehensive.py
 ```
 
+### 6. 同步對齊憑證 (Ping Sync)
+```bash
+npx tsx scripts/ping-sync.ts
+```
+此腳本會在 `_status/ping.txt` 寫入當前時間戳，若環境變數
+`NOTION_API_KEY` 與 `NOTION_DATABASE_ID` 已設定，則會同步至指定的
+Notion 資料庫。
+
 ## 📋 API 端點
 
 | 端點 | 功能 | 回應 |

--- a/scripts/ping-sync.ts
+++ b/scripts/ping-sync.ts
@@ -1,0 +1,47 @@
+import { writeFileSync, mkdirSync } from 'fs';
+import { join } from 'path';
+
+const now = new Date().toISOString();
+
+const statusDir = '_status';
+mkdirSync(statusDir, { recursive: true });
+const file = join(statusDir, 'ping.txt');
+writeFileSync(file, `Ping at ${now}\n`);
+
+console.log(`Ping written to ${file}`);
+
+async function sendToNotion() {
+  const token = process.env.NOTION_API_KEY;
+  const databaseId = process.env.NOTION_DATABASE_ID;
+  if (!token || !databaseId) {
+    console.log('Notion env vars missing, skipping Notion sync');
+    return;
+  }
+
+  const res = await fetch('https://api.notion.com/v1/pages', {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${token}`,
+      'Notion-Version': '2022-06-28',
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      parent: { database_id: databaseId },
+      properties: {
+        Name: {
+          title: [{ text: { content: `Ping ${now}` } }]
+        }
+      }
+    })
+  });
+
+  if (!res.ok) {
+    console.error('Failed to sync to Notion:', await res.text());
+  } else {
+    console.log('Synced to Notion');
+  }
+}
+
+sendToNotion().catch(err => {
+  console.error('Notion request error', err);
+});


### PR DESCRIPTION
## Summary
- add `scripts/ping-sync.ts` to write a ping certificate and optionally sync to Notion
- document running the ping-sync script in README
- ignore Node dependencies in `.gitignore`

## Testing
- `npx tsx scripts/ping-sync.ts`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ad580bdcd4832da34273c8e271c722