### PR TITLE
Fix: Use UTC for consistent result filenames

### DIFF
--- a/particle_core/src/logic_pipeline.py
+++ b/particle_core/src/logic_pipeline.py
@@ -59,7 +59,7 @@ class LogicPipeline:
             "compressed": self.compress_logic(self.fn_steps)
         }
         
-        filename = os.path.join(output_dir, f"logic_result_{datetime.now().strftime('%Y%m%d_%H%M%S')}.json")
+        filename = os.path.join(output_dir, f"logic_result_{datetime.utcnow().strftime('%Y%m%d_%H%M%S')}.json")
         with open(filename, "w", encoding="utf-8") as f:
             json.dump(data, f, ensure_ascii=False, indent=2)
         

--- a/particle_core/src/test_logic_pipeline.py
+++ b/particle_core/src/test_logic_pipeline.py
@@ -1,0 +1,55 @@
+import unittest
+import os
+import json
+from datetime import datetime, timezone
+from logic_pipeline import LogicPipeline
+
+class TestLogicPipeline(unittest.TestCase):
+
+    def setUp(self):
+        self.pipeline = LogicPipeline()
+        self.test_output_dir = "test_output"
+        os.makedirs(self.test_output_dir, exist_ok=True)
+
+    def tearDown(self):
+        for f in os.listdir(self.test_output_dir):
+            os.remove(os.path.join(self.test_output_dir, f))
+        os.rmdir(self.test_output_dir)
+
+    def test_store_result_timestamp_consistency(self):
+        """Tests if the timestamp in the filename and content are consistent."""
+        input_val = "test_input"
+        result = "test_result"
+
+        # Mock datetime.now() to simulate a different timezone
+        from unittest.mock import patch
+        mock_now = datetime(2025, 1, 1, 12, 0, 0)
+
+        from unittest.mock import patch, MagicMock
+        # Simulate that datetime.now() is 8 hours ahead of utcnow()
+        mock_now = datetime(2025, 1, 1, 20, 0, 0)
+        mock_utcnow = datetime(2025, 1, 1, 12, 0, 0)
+
+        with patch('logic_pipeline.datetime', wraps=datetime) as mock_datetime:
+            mock_datetime.now.return_value = mock_now
+            mock_datetime.utcnow.return_value = mock_utcnow
+
+            # Store the result
+            filename = self.pipeline.store_result(input_val, result, output_dir=self.test_output_dir)
+
+            # Extract timestamp from filename
+            file_timestamp_str = os.path.basename(filename).replace("logic_result_", "").replace(".json", "")
+            file_timestamp = datetime.strptime(file_timestamp_str, "%Y%m%d_%H%M%S")
+
+            # Read timestamp from file content
+            with open(filename, "r", encoding="utf-8") as f:
+                data = json.load(f)
+                content_timestamp_str = data["timestamp"]
+                content_timestamp = datetime.fromisoformat(content_timestamp_str).replace(tzinfo=None)
+
+            # Check if timestamps are close (within a reasonable delta, e.g., 2 seconds)
+            time_difference = abs((file_timestamp - content_timestamp).total_seconds())
+            self.assertLess(time_difference, 2, "Timestamp in filename and content should be consistent (UTC)")
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tasks/results/2025-06-29_hello-world-api_result.json
+++ b/tasks/results/2025-06-29_hello-world-api_result.json
@@ -1,6 +1,6 @@
 {
   "task_id": "hello-world-api",
-  "validation_time": "2025-08-02T05:53:17.290236",
+  "validation_time": "2025-09-14T05:05:20.474667",
   "status": "passed",
   "checks": [
     "✓ Target file exists: flow_code/hello_api.py",

--- a/tasks/results/task_processing_summary.json
+++ b/tasks/results/task_processing_summary.json
@@ -1,12 +1,12 @@
 {
-  "processing_time": "2025-08-02T05:53:17.289565",
+  "processing_time": "2025-09-14T05:05:20.473375",
   "total_tasks": 2,
   "passed": 2,
   "failed": 0,
   "tasks": [
     {
       "task_id": "hello-world-api",
-      "validation_time": "2025-08-02T05:53:17.290236",
+      "validation_time": "2025-09-14T05:05:20.474667",
       "status": "passed",
       "checks": [
         "✓ Target file exists: flow_code/hello_api.py",
@@ -16,7 +16,7 @@
     },
     {
       "task_id": "particle-language-core",
-      "validation_time": "2025-08-02T05:53:17.390913",
+      "validation_time": "2025-09-14T05:05:20.701032",
       "status": "passed",
       "checks": [
         "✓ Target directory exists: particle_core/"
@@ -25,5 +25,3 @@
     }
   ]
 }
-
-


### PR DESCRIPTION
The `store_result` function in `logic_pipeline.py` was using `datetime.now()` to generate timestamps for filenames. This could lead to inconsistencies when the code is run in different timezones.

This commit changes the implementation to use `datetime.utcnow()` for generating filenames, ensuring that all timestamps are in UTC and therefore consistent across all environments.

A new test case has been added to verify that the timestamp in the filename is consistent with the UTC timestamp stored in the file's content.